### PR TITLE
adb-multi: Allow using default filenames for non-interactive install

### DIFF
--- a/adb-multi
+++ b/adb-multi
@@ -67,12 +67,14 @@ elif [ "$1" == "generate" ]; then
             filename="$(echo adb-"${device,,}" | sed 's/ //g' | tr -d '\r')"
 
             # Read https://unix.stackexchange.com/a/445154/90681
-            read -p "Do you want to use "$filename" for $device? (Y/n): " -r < /dev/tty
-            if [[ $REPLY =~ ^[Nn]$ ]]; then
-                echo "${yellow}Please name your "$device"!${reset}"
-                read -p 'New name: ' input < /dev/tty
-                filename=adb-$input
-            fi
+            if [ -z "${USE_DEFAULT_FILENAMES}" ]; then
+	            read -p "Do you want to use "$filename" for $device? (Y/n): " -r < /dev/tty
+	            if [[ $REPLY =~ ^[Nn]$ ]]; then
+	                echo "${yellow}Please name your "$device"!${reset}"
+	                read -p 'New name: ' input < /dev/tty
+	                filename=adb-$input
+	            fi
+	        fi
 
             # Check if install directory exists
             if [ ! -d "$path" ]; then


### PR DESCRIPTION
Most people will _not_ want custom names, and with enough devices
installed this gets massively annoying.